### PR TITLE
Shirey/rename uconn

### DIFF
--- a/hubmap_commons/21f293b0-globus-groups.json
+++ b/hubmap_commons/21f293b0-globus-groups.json
@@ -107,15 +107,15 @@
     "tmc_prefix": "STAN"
   },
   {
-    "description": "Users who have access to the University of Connecticut TMC directory.",
+    "description": "Users who have access to the University of Connecticut and Scripps Institute TMC directory.",
     "data_provider": true,
     "has_subgroups": false,
     "identity_set_properties": null,
     "uuid": "301615f9-c870-11eb-a8dc-35ce3d8786fe",
     "group_type": "regular",
-    "name": "HuBMAP-UCONN-TMC",
-    "displayname": "TMC - University of Connecticut",
-    "shortname": "TMC - UConn",
+    "name": "HuBMAP-UCONN-SCRIPPS-TMC",
+    "displayname": "TMC - University of Connecticut and Scripps",
+    "shortname": "TMC - UConn - Scripps",
     "generateuuid": true,
     "tmc_prefix": "UCONN"
   },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="hubmap-commons",
-    version="2.1.3",
+    version="2.1.4",
     author="HuBMAP Consortium",
     author_email="api-developers@hubmapconsortium.org",
     description="The common utilities used by the HuMBAP web services",


### PR DESCRIPTION
Following merged PR #102 but for release after DEV testing

Run this on the neo4j database `match (n {group_uuid:'301615f9-c870-11eb-a8dc-35ce3d8786fe'}) set n.group_name = 'TMC - University of Connecticut and Scripps'` then reindex all