### PR TITLE
Fix "has priv" methods

### DIFF
--- a/hubmap_commons/hm_auth.py
+++ b/hubmap_commons/hm_auth.py
@@ -465,6 +465,8 @@ class AuthHelper:
             return tokenResp        
     
     def getUserInfo(self, token, getGroups = False):
+        if token is None or token.strip() == '':
+            return Response("Auth token required", 400)
         userInfo = AuthCache.getUserInfo(self.getApplicationKey(), token, getGroups)
         
         if isinstance(userInfo, Response):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="hubmap-commons",
-    version="2.1.14",
+    version="2.1.15",
     author="HuBMAP Consortium",
     author_email="api-developers@hubmapconsortium.org",
     description="The common utilities used by the HuMBAP web services",


### PR DESCRIPTION
Fixed issue when no or a blank token was sent to various privilege check methods in AuthHelper.