### PR TITLE
add support for Pipeline-Testing groups

### DIFF
--- a/hubmap_commons/21f293b0-globus-groups.json
+++ b/hubmap_commons/21f293b0-globus-groups.json
@@ -592,6 +592,15 @@
     "displayname": "Workspaces Beta",
     "generateuuid": false,
     "data_provider": false
+  },
+  {
+    "description": "This group gives members access to the HuBMAP pipeline testing facility.",
+    "name": "HuBMAP-Pipeline-Testing",
+    "uuid": "3e5bc7c0-d292-11ef-8694-9f2bd25b4aac",
+    "displayname": "Pipeline Testing",
+    "group_type": "pipeline-testing",
+    "generateuuid": false,
+    "data_provider": false
   }
 ]
 

--- a/hubmap_commons/c4018852-globus-groups.json
+++ b/hubmap_commons/c4018852-globus-groups.json
@@ -382,5 +382,14 @@
 		"shortname": "TMC - Yale - Fan",
 		"generateuuid": true,
 		"tmc_prefix": "YALE1"
+	},
+	{
+		"description": "This group gives members access to the SenNet pipeline testing facility.",
+		"name": "SenNet-Pipeline-Testing",
+		"uuid": "78dedea4-d293-11ef-80ba-178fd5b923bd",
+		"displayname": "Pipeline Testing",
+		"group_type": "pipeline-testing",
+		"generateuuid": false,
+		"data_provider": false
 	}
 ]

--- a/hubmap_commons/hm_auth.py
+++ b/hubmap_commons/hm_auth.py
@@ -170,6 +170,7 @@ class AuthHelper:
         self.data_admin_group_uuid = None
         self.data_read_group_uuid = None
         self.protected_data_group_uuid = None
+        self.pipeline_testing_group_uuid = None
         for grp_name in all_groups.keys():
             grp = all_groups[grp_name]
             if 'group_type' in grp:
@@ -179,6 +180,8 @@ class AuthHelper:
                     self.data_read_group_uuid = grp['uuid']
                 elif grp['group_type'] == 'protected-data':
                     self.protected_data_group_uuid = grp['uuid']
+                elif grp['group_type'] == 'pipeline-testing':
+                    self.pipeline_testing_group_uuid = grp['uuid']
 
         AuthCache.setProcessSecret(re.sub(r'[^a-zA-Z0-9]', '', clientSecret))
         if helperInstance is None:
@@ -357,6 +360,18 @@ class AuthHelper:
         if not self.data_read_group_uuid is None and self.data_read_group_uuid in user_info['hmgroupids']:
             return True
         return self.has_write_privs(groups_token)
+
+    #check to see if a user is allowed to submit jobs to the testing pipeline
+    #users are allowed if they are a member of the "Pipeline Testing" group or
+    #if they are a member of the "Data Admin" group
+    def has_pipeline_testing_privs(self, groups_token):
+        user_info = self.getUserInfo(groups_token, getGroups = True)
+        if isinstance(user_info, Response):
+            return user_info
+        if (not self.pipeline_testing_group_uuid is None and self.pipeline_testing_group_uuid in user_info['hmgroupids']) or (not self.data_admin_group_uuid is None and self.data_admin_group_uuid in user_info['hmgroupids']):
+            return True
+        else:
+            return False
 
     def get_default_read_group_uuid(self):
         return self.data_read_group_uuid

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="hubmap-commons",
-    version="2.1.18",
+    version="2.1.19",
     author="HuBMAP Consortium",
     author_email="api-developers@hubmapconsortium.org",
     description="The common utilities used by the HuMBAP web services",


### PR DESCRIPTION
For both HuBMAP and SenNet added support for new Pipeline-Testing groups.

This is required for a new version of ingest-api, released with [ingest-api PR #683](https://github.com/hubmapconsortium/ingest-api/pull/683)