### PR TITLE
Add accessor method for proteted group uuid

### DIFF
--- a/hubmap_commons/hm_auth.py
+++ b/hubmap_commons/hm_auth.py
@@ -655,6 +655,8 @@ class AuthHelper:
                     break
         return return_list
 
+    def get_protected_data_group_uuid(self):
+        return self.protected_data_group_uuid
 
 def identifyGroups(groups):
     groupIdByName = {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="hubmap-commons",
-    version="2.1.21",
+    version="2.1.22",
     author="HuBMAP Consortium",
     author_email="api-developers@hubmapconsortium.org",
     description="The common utilities used by the HuMBAP web services",


### PR DESCRIPTION
Add accessor method for proteted group uuid.  This is needed for the recent update in entity-api to add functionality to the globus-url endpoint supporting new public versions of protected data: https://github.com/hubmapconsortium/entity-api/pull/958 